### PR TITLE
Updated stride dependencies to the latest versions for 4.2.0.2267 engine

### DIFF
--- a/MiyaGrace.Stride.Common/MiyaGrace.Stride.Common.csproj
+++ b/MiyaGrace.Stride.Common/MiyaGrace.Stride.Common.csproj
@@ -1,23 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-	<PropertyGroup>
-		<TargetFrameworks>net8.0-windows;net8.0</TargetFrameworks>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="Stride.CommunityToolkit" Version="1.0.0-preview.45" />
-		<PackageReference Include="Stride.Engine" Version="4.2.0.2232" PrivateAssets="contentfiles;analyzers" />
-		<PackageReference Include="Stride.Video" Version="4.2.0.2232" PrivateAssets="contentfiles;analyzers" />
-		<PackageReference Include="Stride.Physics" Version="4.2.0.2232" PrivateAssets="contentfiles;analyzers" />
-		<PackageReference Include="Stride.Navigation" Version="4.2.0.2232" PrivateAssets="contentfiles;analyzers" />
-		<PackageReference Include="Stride.Particles" Version="4.2.0.2232" PrivateAssets="contentfiles;analyzers" />
-		<PackageReference Include="Stride.UI" Version="4.2.0.2232" PrivateAssets="contentfiles;analyzers" />
-		<PackageReference Include="Stride.Core" Version="4.2.0.2232" PrivateAssets="contentfiles;analyzers" />
-		<PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.2.0.2232" PrivateAssets="contentfiles;analyzers" IncludeAssets="build" />
-	</ItemGroup>
-	<ItemGroup>
-	  <Folder Include="Assets\" />
-	  <Folder Include="Resources\Textures\" />
-	</ItemGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-windows;net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Stride.CommunityToolkit" Version="1.0.0-preview.46" />
+    <PackageReference Include="Stride.Engine" Version="4.2.0.2267" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Stride.Video" Version="4.2.0.2267" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Stride.Physics" Version="4.2.0.2267" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Stride.Navigation" Version="4.2.0.2267" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Stride.Particles" Version="4.2.0.2267" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Stride.UI" Version="4.2.0.2267" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Stride.Core" Version="4.2.0.2267" PrivateAssets="contentfiles;analyzers" />
+    <PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.2.0.2267" PrivateAssets="contentfiles;analyzers" IncludeAssets="build" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Assets\" />
+    <Folder Include="Resources\Textures\" />
+  </ItemGroup>
 </Project>

--- a/SandboxSceneBrowser/SandboxSceneBrowser.Windows/SandboxSceneBrowser.Windows.csproj
+++ b/SandboxSceneBrowser/SandboxSceneBrowser.Windows/SandboxSceneBrowser.Windows.csproj
@@ -1,21 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
-    <ApplicationIcon>Resources\Icon.ico</ApplicationIcon>
-    <OutputType>WinExe</OutputType>
-    <RootNamespace>CommonLibSandbox</RootNamespace>
+	<PropertyGroup>
+		<TargetFramework>net8.0-windows</TargetFramework>
+		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
+		<ApplicationIcon>Resources\Icon.ico</ApplicationIcon>
+		<OutputType>WinExe</OutputType>
+		<RootNamespace>CommonLibSandbox</RootNamespace>
+		<ApplicationManifest>app.manifest</ApplicationManifest>
 
-    <OutputPath>..\Bin\Windows\$(Configuration)\</OutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<OutputPath>..\Bin\Windows\$(Configuration)\</OutputPath>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 
-    <!-- Force msbuild to check to rebuild this assembly instead of letting VS IDE guess -->
-    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
-  </PropertyGroup>
+		<!-- Force msbuild to check to rebuild this assembly instead of letting VS IDE guess -->
+		<DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\SandboxSceneBrowser\SandboxSceneBrowser.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\SandboxSceneBrowser\SandboxSceneBrowser.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/SandboxSceneBrowser/SandboxSceneBrowser/SandboxSceneBrowser.csproj
+++ b/SandboxSceneBrowser/SandboxSceneBrowser/SandboxSceneBrowser.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFrameworks>net8.0-windows</TargetFrameworks>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="Stride.Engine" Version="4.2.0.2232" />
-		<PackageReference Include="Stride.Video" Version="4.2.0.2232" />
-		<PackageReference Include="Stride.Physics" Version="4.2.0.2232" />
-		<PackageReference Include="Stride.Navigation" Version="4.2.0.2232" />
-		<PackageReference Include="Stride.Particles" Version="4.2.0.2232" />
-		<PackageReference Include="Stride.UI" Version="4.2.0.2232" />
-		<PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.2.0.2232" IncludeAssets="build;buildTransitive" />
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\..\MiyaGrace.Stride.Common\MiyaGrace.Stride.Common.csproj" />
-	</ItemGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-windows</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Stride.Engine" Version="4.2.0.2267" />
+    <PackageReference Include="Stride.Video" Version="4.2.0.2267" />
+    <PackageReference Include="Stride.Physics" Version="4.2.0.2267" />
+    <PackageReference Include="Stride.Navigation" Version="4.2.0.2267" />
+    <PackageReference Include="Stride.Particles" Version="4.2.0.2267" />
+    <PackageReference Include="Stride.UI" Version="4.2.0.2267" />
+    <PackageReference Include="Stride.Core.Assets.CompilerApp" Version="4.2.0.2267" IncludeAssets="build;buildTransitive" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\MiyaGrace.Stride.Common\MiyaGrace.Stride.Common.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated to build and run in the latest version of the engine (4.2.0.2267).